### PR TITLE
Fix notices flooding error logs during schedule importing (#508)

### DIFF
--- a/src/Client/GuzzleAdapter.php
+++ b/src/Client/GuzzleAdapter.php
@@ -44,10 +44,6 @@ class GuzzleAdapter implements ClientInterface
                 throw new \RuntimeException($data['error_message']);
             }
 
-            if (!isset($data['results'])) {
-                throw new \RuntimeException('The response does not contain a results key.');
-            }
-
             return $data;
         } catch (\Exception $e) {
             throw new \RuntimeException($e->getMessage(), 0, $e);

--- a/src/Client/GuzzleAdapter.php
+++ b/src/Client/GuzzleAdapter.php
@@ -38,8 +38,14 @@ class GuzzleAdapter implements ClientInterface
                 throw new \RuntimeException('Failed to parse response');
             }
 
-            if ($data['status'] !== 'OK') {
+            if ($data['status'] !== 'OK'
+                && isset($data['error_message'])
+            ) {
                 throw new \RuntimeException($data['error_message']);
+            }
+
+            if (!isset($data['results'])) {
+                throw new \RuntimeException('The response does not contain a results key.');
             }
 
             return $data;


### PR DESCRIPTION
-Make sure error_message is set before trying to use it in an exception.  Google can respond with non-"OK" responses like "ZERO-RESULTS" which isn't an error and doesn't have an error_message.  It's a valid result to return because 'results' should be set and empty and everything should function fine with it.
-Add a check for 'results' key being set in return data since our code that uses this dependency expects it.